### PR TITLE
fix(kqueue): preserve create events when child watch fails

### DIFF
--- a/watcher_freebsd.go
+++ b/watcher_freebsd.go
@@ -357,6 +357,7 @@ func (w *Watcher) diffDir(dir *kqWatch, requested Op) {
 	}
 
 	var added []string
+	var registerErrs []error
 
 	w.mu.Lock()
 	if w.closed {
@@ -373,12 +374,16 @@ func (w *Watcher) diffDir(dir *kqWatch, requested Op) {
 			continue
 		}
 		childPath := filepath.Join(dir.path, name)
+		// The directory entry was observed even when child watch registration
+		// fails; emit Create, then surface the error because future events for
+		// this child are not guaranteed without a watch.
+		added = append(added, childPath)
 		child, err := w.openLocked(childPath, requested, dir)
 		if err != nil {
+			registerErrs = append(registerErrs, fmt.Errorf("fsnotify: register %s: %w", childPath, err))
 			continue
 		}
 		dir.children[name] = child
-		added = append(added, childPath)
 		if recursive && child.isDir {
 			// mkdir -p (or a populated subtree moved in) lands all the
 			// nested entries before NOTE_WRITE reaches us; report them
@@ -392,6 +397,9 @@ func (w *Watcher) diffDir(dir *kqWatch, requested Op) {
 		for _, p := range added {
 			w.sendEvent(Event{Name: p, Op: Create})
 		}
+	}
+	for _, err := range registerErrs {
+		w.sendError(err)
 	}
 }
 

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -122,6 +122,47 @@ func TestWatchFileWrite(t *testing.T) {
 	}
 }
 
+func TestKqueueCreateReportsChildRegistrationFailure(t *testing.T) {
+	if runtime.GOOS != "freebsd" {
+		t.Skip("kqueue regression test")
+	}
+	dir := tempDir(t)
+	target := filepath.Join(dir, "dangling-link")
+
+	w := newWatcher(t)
+	if err := w.Add(dir, Create|Write); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "missing-target"), target); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	var sawCreate bool
+	var sawRegisterErr bool
+	deadline := time.NewTimer(eventTimeout)
+	defer deadline.Stop()
+	for !sawCreate || !sawRegisterErr {
+		select {
+		case ev, ok := <-w.Events:
+			if !ok {
+				t.Fatalf("Events channel closed early")
+			}
+			if ev.Name == target && ev.Op.Has(Create) {
+				sawCreate = true
+			}
+		case err, ok := <-w.Errors:
+			if !ok {
+				t.Fatalf("Errors channel closed early")
+			}
+			if strings.Contains(err.Error(), "fsnotify: register "+target+":") {
+				sawRegisterErr = true
+			}
+		case <-deadline.C:
+			t.Fatalf("timeout waiting for Create and registration error; sawCreate=%v sawRegisterErr=%v", sawCreate, sawRegisterErr)
+		}
+	}
+}
+
 func TestWatchRemove(t *testing.T) {
 	dir := tempDir(t)
 	target := filepath.Join(dir, "a.txt")


### PR DESCRIPTION
This keeps directory Create notifications observable even when registering the new child watch fails, while still registering successful child watches before delivering Create so a following Write is not missed.

Tested with `go test ./...`.