### PR TITLE
Update macOS backend docs to reflect purego implementation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -74,24 +74,19 @@ timeout grows rather than `-race` getting dropped.
 
 ## Platform support
 
-| OS      | Backend                | Status    |
-|---------|------------------------|-----------|
-| Linux   | inotify                | Supported |
-| Windows | ReadDirectoryChangesW  | Supported |
-| macOS   | FSEvents (cgo)         | Supported |
-| macOS   | kqueue (CGO_ENABLED=0) | Supported |
-| FreeBSD | kqueue                 | Supported |
-| other   | stub returning `ErrUnsupported` | — |
+| OS      | Backend                         | Status    |
+|---------|---------------------------------|-----------|
+| Linux   | inotify                         | Supported |
+| Windows | ReadDirectoryChangesW           | Supported |
+| macOS   | FSEvents (purego)               | Supported |
+| FreeBSD | kqueue                          | Supported |
+| other   | stub returning `ErrUnsupported` | —         |
 
-### macOS backend selection
+### macOS backend
 
-On macOS, the default backend is FSEvents (requires cgo, which is
-enabled by default). FSEvents monitors paths at the volume level
-without opening a file descriptor per watched entry, and supports
-native recursive watching — `AddRecursive` creates a single stream
+On macOS the backend is FSEvents, called through
+[`purego`](https://github.com/ebitengine/purego) so cgo is not
+required. FSEvents monitors paths at the volume level without
+opening a file descriptor per watched entry, and supports native
+recursive watching — `AddRecursive` creates a single stream
 regardless of tree depth.
-
-When building with `CGO_ENABLED=0`, the kqueue backend is used
-instead. It opens a file descriptor per watched file/directory and
-walks the tree manually for `AddRecursive`, but requires no cgo
-dependency.

--- a/README.md
+++ b/README.md
@@ -76,13 +76,12 @@ Paths are canonicalized (absolute, cleaned, with symlinks resolved when the targ
 
 ## Platform Support
 
-| OS      | Backend                | Status    |
-|---------|------------------------|-----------|
-| Linux   | inotify                | Supported |
-| Windows | ReadDirectoryChangesW  | Supported |
-| macOS   | FSEvents (cgo)         | Supported |
-| macOS   | kqueue (CGO_ENABLED=0) | Supported |
-| FreeBSD | kqueue                 | Supported |
+| OS      | Backend                 | Status    |
+|---------|-------------------------|-----------|
+| Linux   | inotify                 | Supported |
+| Windows | ReadDirectoryChangesW   | Supported |
+| macOS   | FSEvents (purego)       | Supported |
+| FreeBSD | kqueue                  | Supported |
 
 ## License
 


### PR DESCRIPTION
The platform support tables in README.md and DESIGN.md still listed FSEvents (cgo) plus a non-existent macOS kqueue (CGO_ENABLED=0) backend after dd1d3d4 switched the FSEvents backend to purego. The only kqueue file in the tree is watcher_freebsd.go, and watcher_darwin.go has the unconditional //go:build darwin tag, so the previous wording was misleading. This PR collapses the two macOS rows into a single FSEvents (purego) row and rewrites the macOS backend section in DESIGN.md to drop the cgo/kqueue split that no longer exists.