### PR TITLE
Add .gitignore for CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
Add a .gitignore that ignores CLAUDE.md so a local copy of AGENTS.md can be kept at CLAUDE.md (Claude Code auto-loads CLAUDE.md but does not always pick up AGENTS.md). AGENTS.md remains the single committed source of truth, and contributors can run cp AGENTS.md CLAUDE.md locally without polluting the repo.