### PR TITLE
Drop Windows watch entry on aborted ReadDirectoryChangesW completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Windows: drop the watch entry and close the directory handle when `ReadDirectoryChangesW` completes with `ERROR_OPERATION_ABORTED`/`ERROR_INVALID_HANDLE` so a deleted or disconnected watched root no longer leaks a `winWatch`; also surface a `Remove` event for the root, matching the other backends
+
 ## [0.0.4] - 2026-05-07
 
 ### Added

--- a/path_windows_test.go
+++ b/path_windows_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 func TestCanonicalizeExpandsShortPath(t *testing.T) {
@@ -36,5 +37,49 @@ func TestCanonicalizeExpandsShortPath(t *testing.T) {
 	}
 	if !strings.EqualFold(got, long) {
 		t.Errorf("canonicalize(%q) = %q, want %q", short, got, long)
+	}
+}
+
+// TestDropWatchReleasesEntry exercises the readLoop's recovery path for
+// an aborted ReadDirectoryChangesW completion (e.g. a watched drive is
+// ejected or the directory is force-deleted out from under the
+// watcher). Calling dropWatch must remove the map entry, close the
+// handle, and emit a Remove event so callers learn the root is gone.
+func TestDropWatchReleasesEntry(t *testing.T) {
+	dir := tempDir(t)
+	w := newWatcher(t)
+	if err := w.Add(dir, Remove); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	var key uint32
+	w.mu.Lock()
+	for k := range w.watches {
+		key = k
+	}
+	w.mu.Unlock()
+	if key == 0 {
+		t.Fatalf("no watch registered")
+	}
+
+	w.dropWatch(key)
+
+	w.mu.Lock()
+	_, present := w.watches[key]
+	w.mu.Unlock()
+	if present {
+		t.Fatalf("watch entry not removed after dropWatch")
+	}
+
+	select {
+	case ev, ok := <-w.Events:
+		if !ok {
+			t.Fatalf("Events closed before Remove arrived")
+		}
+		if ev.Op != Remove || ev.Name != dir {
+			t.Errorf("event = %+v, want Remove %q", ev, dir)
+		}
+	case <-time.After(eventTimeout):
+		t.Fatalf("timeout waiting for Remove event")
 	}
 }

--- a/watcher_windows.go
+++ b/watcher_windows.go
@@ -232,8 +232,13 @@ func (w *Watcher) readLoop() {
 		default:
 		}
 		if err != nil {
-			// Aborted reads come from CloseHandle on a watched directory; not fatal.
+			// Aborted/invalid-handle completions come from either an
+			// explicit Remove (already cleaned up) or the watched
+			// directory being deleted out from under us. In the latter
+			// case the entry is still in the map, so drop it to release
+			// the handle and surface a Remove event for the root.
 			if errors.Is(err, syscall.ERROR_OPERATION_ABORTED) || errors.Is(err, errorInvalidHandle) {
+				w.dropWatch(key)
 				continue
 			}
 			w.sendError(err)
@@ -291,6 +296,31 @@ func (w *Watcher) handleCompletion(key uint32, n uint32) {
 	if err := ww.startRead(); err != nil {
 		if !errors.Is(err, syscall.ERROR_OPERATION_ABORTED) {
 			w.sendError(err)
+		}
+	}
+}
+
+// dropWatch removes the watch entry for key if it is still present and
+// closes its handle. Called when ReadDirectoryChangesW completes with
+// an aborted/invalid-handle status so a deleted watched directory does
+// not leak its winWatch (handle, buffer, overlapped). Also surfaces a
+// Remove event for the root path when the user requested Remove and
+// the entry was still tracked, matching IN_DELETE_SELF on Linux.
+func (w *Watcher) dropWatch(key uint32) {
+	w.mu.Lock()
+	ww, ok := w.watches[key]
+	if ok {
+		delete(w.watches, key)
+	}
+	w.mu.Unlock()
+	if !ok {
+		return
+	}
+	syscall.CloseHandle(ww.handle)
+	if ww.op.Has(Remove) {
+		select {
+		case w.Events <- Event{Name: ww.path, Op: Remove}:
+		case <-w.done:
 		}
 	}
 }


### PR DESCRIPTION
On Windows, when the watched root directory is deleted or its volume becomes unreachable (drive eject, network share lost), the IOCP delivers `ERROR_OPERATION_ABORTED` or `ERROR_INVALID_HANDLE` for the pending `ReadDirectoryChangesW` read. The previous code simply `continue`d, leaving the `winWatch` (handle, 4KB buffer, overlapped) in `w.watches` until the user called `Close`. Because the directory handle was opened with `FILE_SHARE_DELETE`, the directory could even sit in pending-delete state on the filesystem until the watcher released its handle.

This change adds `dropWatch(key)` and calls it from the abort path. If the entry is still present, it is removed from the map, the handle is closed, and a `Remove` event is emitted for the root path when the user requested `Remove`. Aborts caused by an explicit `Remove()` are unaffected because that path deletes the entry before closing the handle, so the lookup is a no-op and no spurious event is delivered.

The new behavior matches the other backends:
- Linux: `IN_DELETE_SELF` + `IN_IGNORED` cleanup in `dispatch`
- FreeBSD: `NOTE_DELETE` triggering `closeTreeLocked` and a `Remove` event
- macOS: `fseRootChanged` stopping the stream and emitting `Remove`/`Rename`

Subdirectory deletion under `AddRecursive` was already handled by the kernel via `bWatchSubtree`, so only the root-deletion case needed fixing.

A Windows-only unit test calls `dropWatch` directly and verifies the map entry is removed, the handle is closed, and a `Remove` event is emitted on the watched path. A filesystem-level trigger was avoided because Windows `FILE_SHARE_DELETE` semantics make abort delivery on directory deletion timing-dependent.

Local checks: `GOOS=windows go vet ./...`, `GOOS=windows go build ./...`, `GOOS=windows go test -c ./...`, and `go test ./...` on Linux all pass.