### PR TITLE
Make Op.Has return true when any bit in target is set

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -26,9 +26,9 @@ const (
 // All is the union of every supported Op bit.
 const All = Create | Write | Remove | Rename | Chmod
 
-// Has reports whether op contains every bit set in target.
+// Has reports whether op contains any bit set in target.
 func (op Op) Has(target Op) bool {
-	return op&target == target
+	return op&target != 0
 }
 
 // String returns a human-readable representation such as "CREATE|WRITE".

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -1,0 +1,50 @@
+package fsnotify
+
+import "testing"
+
+func TestOpString(t *testing.T) {
+	tests := []struct {
+		op   Op
+		want string
+	}{
+		{0, ""},
+		{Create, "CREATE"},
+		{Write, "WRITE"},
+		{Remove, "REMOVE"},
+		{Rename, "RENAME"},
+		{Chmod, "CHMOD"},
+		{Create | Write, "CREATE|WRITE"},
+		{Create | Chmod, "CREATE|CHMOD"},
+		{All, "CREATE|WRITE|REMOVE|RENAME|CHMOD"},
+	}
+	for _, tt := range tests {
+		if got := tt.op.String(); got != tt.want {
+			t.Errorf("Op(%d).String() = %q, want %q", tt.op, got, tt.want)
+		}
+	}
+}
+
+func TestOpHas(t *testing.T) {
+	tests := []struct {
+		name   string
+		op     Op
+		target Op
+		want   bool
+	}{
+		{"single bit set", Create, Create, true},
+		{"single bit unset", Write, Create, false},
+		{"any of multiple bits set", Create, Create | Write, true},
+		{"all of multiple bits set", Create | Write, Create | Write, true},
+		{"none of multiple bits set", Chmod, Create | Write, false},
+		{"superset of target", Create | Write | Chmod, Create | Write, true},
+		{"empty op against any", 0, Create, false},
+		{"empty target", Create, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.op.Has(tt.target); got != tt.want {
+				t.Errorf("Op(%s).Has(%s) = %v, want %v", tt.op, tt.target, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Change `Op.Has` to report whether `op` contains any bit set in `target` instead of every bit. This lets callers express "matches any of these flags" with `ev.Op.Has(Create | Write)`, which previously required `||`-chaining individual single-bit calls. Behavior is unchanged for single-bit targets, which is how every existing call site (in `String`, the platform watchers, and the test helpers) uses `Has`.

Adds unit tests for the new semantics and a regression test for `Op.String` so future changes to `Has` cannot silently break the join logic.