### PR TITLE
Make Watcher.Events and Watcher.Errors directional and fix race condition

### DIFF
--- a/watcher_darwin.go
+++ b/watcher_darwin.go
@@ -151,15 +151,16 @@ type Watcher struct {
 	events chan<- Event
 	errors chan<- error
 
-	mu       sync.Mutex
-	id       uintptr
-	queue    uintptr // dispatch_queue_t
-	streams  map[string]*fsStream
-	cleanupW sync.WaitGroup
-	internal chan Event
-	closed   bool
-	done     chan struct{}
-	exited   chan struct{}
+	mu          sync.Mutex
+	id          uintptr
+	queue       uintptr // dispatch_queue_t
+	streams     map[string]*fsStream
+	cleanupW    sync.WaitGroup
+	internal    chan Event
+	internalErr chan error
+	closed      bool
+	done        chan struct{}
+	exited      chan struct{}
 }
 
 // Global registry maps watcher IDs to watchers so the callback
@@ -214,15 +215,16 @@ func NewWatcher() (*Watcher, error) {
 	events := make(chan Event, 64)
 	errors := make(chan error, 8)
 	w := &Watcher{
-		Events:   events,
-		Errors:   errors,
-		queue:    queue,
-		streams:  make(map[string]*fsStream),
-		internal: make(chan Event, 256),
-		done:     make(chan struct{}),
-		exited:   make(chan struct{}),
-		events:   events,
-		errors:   errors,
+		Events:      events,
+		Errors:      errors,
+		events:      events,
+		errors:      errors,
+		queue:       queue,
+		streams:     make(map[string]*fsStream),
+		internal:    make(chan Event, 256),
+		internalErr: make(chan error, 8),
+		done:        make(chan struct{}),
+		exited:      make(chan struct{}),
 	}
 	w.id = registerWatcher(w)
 	go w.readLoop()
@@ -242,6 +244,12 @@ func (w *Watcher) readLoop() {
 		case ev := <-w.internal:
 			select {
 			case w.events <- ev:
+			case <-w.done:
+				return
+			}
+		case err := <-w.internalErr:
+			select {
+			case w.errors <- err:
 			case <-w.done:
 				return
 			}
@@ -525,7 +533,7 @@ func (w *Watcher) sendEvent(e Event) {
 
 func (w *Watcher) sendError(err error) {
 	select {
-	case w.errors <- err:
+	case w.internalErr <- err:
 	case <-w.done:
 	}
 }

--- a/watcher_darwin.go
+++ b/watcher_darwin.go
@@ -156,7 +156,7 @@ type Watcher struct {
 	queue       uintptr // dispatch_queue_t
 	streams     map[string]*fsStream
 	cleanupW    sync.WaitGroup
-	internal    chan Event
+	internalEv  chan Event
 	internalErr chan error
 	closed      bool
 	done        chan struct{}
@@ -221,7 +221,7 @@ func NewWatcher() (*Watcher, error) {
 		errors:      errors,
 		queue:       queue,
 		streams:     make(map[string]*fsStream),
-		internal:    make(chan Event, 256),
+		internalEv:  make(chan Event, 256),
 		internalErr: make(chan error, 8),
 		done:        make(chan struct{}),
 		exited:      make(chan struct{}),
@@ -241,7 +241,7 @@ func (w *Watcher) readLoop() {
 
 	for {
 		select {
-		case ev := <-w.internal:
+		case ev := <-w.internalEv:
 			select {
 			case w.events <- ev:
 			case <-w.done:
@@ -526,7 +526,7 @@ func isUnder(child, parent string) bool {
 
 func (w *Watcher) sendEvent(e Event) {
 	select {
-	case w.internal <- e:
+	case w.internalEv <- e:
 	case <-w.done:
 	}
 }

--- a/watcher_darwin.go
+++ b/watcher_darwin.go
@@ -144,9 +144,12 @@ type fsStream struct {
 // Watcher monitors registered paths via macOS FSEvents.
 type Watcher struct {
 	// Events delivers change notifications. Closed when Close returns.
-	Events chan Event
+	Events <-chan Event
 	// Errors delivers non-fatal errors from the read loop. Closed when Close returns.
-	Errors chan error
+	Errors <-chan error
+
+	events chan<- Event
+	errors chan<- error
 
 	mu       sync.Mutex
 	id       uintptr
@@ -208,14 +211,18 @@ func NewWatcher() (*Watcher, error) {
 
 	queue := _dispatchQueueCreate("github.com/gofsnotify/fsnotify\x00", 0)
 
+	events := make(chan Event, 64)
+	errors := make(chan error, 8)
 	w := &Watcher{
-		Events:   make(chan Event, 64),
-		Errors:   make(chan error, 8),
+		Events:   events,
+		Errors:   errors,
 		queue:    queue,
 		streams:  make(map[string]*fsStream),
 		internal: make(chan Event, 256),
 		done:     make(chan struct{}),
 		exited:   make(chan struct{}),
+		events:   events,
+		errors:   errors,
 	}
 	w.id = registerWatcher(w)
 	go w.readLoop()
@@ -227,14 +234,14 @@ func NewWatcher() (*Watcher, error) {
 // Errors, and exited, matching the pattern of the other backends.
 func (w *Watcher) readLoop() {
 	defer close(w.exited)
-	defer close(w.Events)
-	defer close(w.Errors)
+	defer close(w.events)
+	defer close(w.errors)
 
 	for {
 		select {
 		case ev := <-w.internal:
 			select {
-			case w.Events <- ev:
+			case w.events <- ev:
 			case <-w.done:
 				return
 			}
@@ -518,7 +525,7 @@ func (w *Watcher) sendEvent(e Event) {
 
 func (w *Watcher) sendError(err error) {
 	select {
-	case w.Errors <- err:
+	case w.errors <- err:
 	case <-w.done:
 	}
 }

--- a/watcher_freebsd.go
+++ b/watcher_freebsd.go
@@ -19,9 +19,12 @@ const oEvtOnly = 0x8000
 // for files inside the directory, matching the Linux/Windows backends.
 type Watcher struct {
 	// Events delivers change notifications. Closed when Close returns.
-	Events chan Event
+	Events <-chan Event
 	// Errors delivers non-fatal errors from the read loop. Closed when Close returns.
-	Errors chan error
+	Errors <-chan error
+
+	events chan<- Event
+	errors chan<- error
 
 	mu     sync.Mutex
 	kq     int
@@ -66,9 +69,14 @@ func NewWatcher() (*Watcher, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	events := make(chan Event, 64)
+	errors := make(chan error, 8)
 	w := &Watcher{
-		Events: make(chan Event, 64),
-		Errors: make(chan error, 8),
+		Events: events,
+		Errors: errors,
+		events: events,
+		errors: errors,
 		kq:     kq,
 		roots:  make(map[string]*kqWatch),
 		byFd:   make(map[int]*kqWatch),
@@ -239,8 +247,8 @@ func (w *Watcher) closeTreeLocked(ww *kqWatch) {
 
 func (w *Watcher) readLoop() {
 	defer close(w.exited)
-	defer close(w.Events)
-	defer close(w.Errors)
+	defer close(w.events)
+	defer close(w.errors)
 
 	events := make([]syscall.Kevent_t, 16)
 	for {
@@ -368,14 +376,14 @@ func (w *Watcher) diffDir(dir *kqWatch, requested Op) {
 
 func (w *Watcher) sendEvent(e Event) {
 	select {
-	case w.Events <- e:
+	case w.events <- e:
 	case <-w.done:
 	}
 }
 
 func (w *Watcher) sendError(err error) {
 	select {
-	case w.Errors <- err:
+	case w.errors <- err:
 	case <-w.done:
 	}
 }

--- a/watcher_linux.go
+++ b/watcher_linux.go
@@ -17,9 +17,12 @@ import (
 // Watcher monitors registered paths for file system changes via inotify.
 type Watcher struct {
 	// Events delivers change notifications. Closed when Close returns.
-	Events chan Event
+	Events <-chan Event
 	// Errors delivers non-fatal errors from the read loop. Closed when Close returns.
-	Errors chan error
+	Errors <-chan error
+
+	events chan<- Event
+	errors chan<- error
 
 	mu      sync.Mutex
 	fd      int
@@ -47,9 +50,14 @@ func NewWatcher() (*Watcher, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	events := make(chan Event, 64)
+	errors := make(chan error, 8)
 	w := &Watcher{
-		Events:  make(chan Event, 64),
-		Errors:  make(chan error, 8),
+		Events:  events,
+		Errors:  errors,
+		events:  events,
+		errors:  errors,
 		fd:      fd,
 		file:    os.NewFile(uintptr(fd), "inotify"),
 		watches: make(map[string]*linuxWatch),
@@ -196,8 +204,8 @@ func (w *Watcher) Close() error {
 
 func (w *Watcher) readLoop() {
 	defer close(w.exited)
-	defer close(w.Events)
-	defer close(w.Errors)
+	defer close(w.events)
+	defer close(w.errors)
 
 	var buf [4096]byte
 	for {
@@ -305,15 +313,19 @@ func (w *Watcher) dispatch(wd int32, mask uint32, name string) {
 	if op == 0 {
 		return
 	}
+	w.sendEvent(Event{Name: full, Op: op})
+}
+
+func (w *Watcher) sendEvent(e Event) {
 	select {
-	case w.Events <- Event{Name: full, Op: op}:
+	case w.events <- e:
 	case <-w.done:
 	}
 }
 
 func (w *Watcher) sendError(err error) {
 	select {
-	case w.Errors <- err:
+	case w.errors <- err:
 	case <-w.done:
 	}
 }

--- a/watcher_windows.go
+++ b/watcher_windows.go
@@ -33,9 +33,12 @@ type fileNotifyInformation struct {
 // Watcher monitors registered paths via ReadDirectoryChangesW.
 type Watcher struct {
 	// Events delivers change notifications. Closed when Close returns.
-	Events chan Event
+	Events <-chan Event
 	// Errors delivers non-fatal errors from the read loop. Closed when Close returns.
-	Errors chan error
+	Errors <-chan error
+
+	events chan<- Event
+	errors chan<- error
 
 	mu      sync.Mutex
 	port    syscall.Handle
@@ -66,9 +69,13 @@ func NewWatcher() (*Watcher, error) {
 	if err != nil {
 		return nil, err
 	}
+	events := make(chan Event, 64)
+	errors := make(chan error, 8)
 	w := &Watcher{
-		Events:  make(chan Event, 64),
-		Errors:  make(chan error, 8),
+		Events:  events,
+		Errors:  errors,
+		events:  events,
+		errors:  errors,
 		port:    port,
 		watches: make(map[uint32]*winWatch),
 		done:    make(chan struct{}),
@@ -216,8 +223,8 @@ func (ww *winWatch) startRead() error {
 
 func (w *Watcher) readLoop() {
 	defer close(w.exited)
-	defer close(w.Events)
-	defer close(w.Errors)
+	defer close(w.events)
+	defer close(w.errors)
 
 	for {
 		var (
@@ -280,11 +287,7 @@ func (w *Watcher) handleCompletion(key uint32, n uint32) {
 			if name != "" {
 				full = filepath.Join(ww.path, name)
 			}
-			select {
-			case w.Events <- Event{Name: full, Op: op}:
-			case <-w.done:
-				return
-			}
+			w.sendEvent(Event{Name: full, Op: op})
 		}
 
 		if raw.NextEntryOffset == 0 {
@@ -318,16 +321,20 @@ func (w *Watcher) dropWatch(key uint32) {
 	}
 	syscall.CloseHandle(ww.handle)
 	if ww.op.Has(Remove) {
-		select {
-		case w.Events <- Event{Name: ww.path, Op: Remove}:
-		case <-w.done:
-		}
+		w.sendEvent(Event{Name: ww.path, Op: Remove})
+	}
+}
+
+func (w *Watcher) sendEvent(e Event) {
+	select {
+	case w.events <- e:
+	case <-w.done:
 	}
 }
 
 func (w *Watcher) sendError(err error) {
 	select {
-	case w.Errors <- err:
+	case w.errors <- err:
 	case <-w.done:
 	}
 }


### PR DESCRIPTION
`Watcher.Events` is bidirectional, so users can accidentally close the channel.

```go
package main

import "github.com/gofsnotify/fsnotify"

func main() {
	w, err := fsnotify.NewWatcher()
	if err != nil {
		panic(err)
	}
	defer w.Close()

	close(w.Events) // Users can close `Watcher.Events`
}
```

This code causes a runtime panic.

```
% go run cmd/hoge/main.go
panic: close of closed channel

goroutine 20 [running]:
github.com/gofsnotify/fsnotify.(*Watcher).readLoop(0x29643b9a180)
        /Users/shogo/pkg/mod/github.com/gofsnotify/fsnotify@v0.0.5/watcher_darwin.go:242 +0x1a0
created by github.com/gofsnotify/fsnotify.NewWatcher in goroutine 1
        /Users/shogo/pkg/mod/github.com/gofsnotify/fsnotify@v0.0.5/watcher_darwin.go:221 +0x170
exit status 2
```

By making `Watcher.Events` and `Watcher.Errors` receive-only channels, users can catch this mistake at compile time.

```
% go run cmd/hoge/main.go
# command-line-arguments
cmd/hoge/main.go:12:8: invalid operation: cannot close receive-only channel w.Events (variable of type <-chan fsnotify.Event)
```

---

In `watcher_darwin.go`, `close(w.error)` and `w.error <- err` were being executed in separate goroutines.
This is a race condition, as it is uncertain which one will be executed first.

@coderabbitai caught it, thanks