### PR TITLE
APFS, the default file system of macOS, is case-insensitive and Unicode-normalization-insensitive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.25.0
 require (
 	github.com/ebitengine/purego v0.10.0
 	golang.org/x/sys v0.44.0
+	golang.org/x/text v0.37.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=

--- a/path_darwin.go
+++ b/path_darwin.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package fsnotify
+
+import (
+	"golang.org/x/text/cases"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+// pathKey returns a comparison key for p. APFS is case-insensitive,
+// so fold the case before using a path as a map key.
+// APFS is also Unicode-normalization-insensitive, so normalize to NFD as well.
+func pathKey(p string) string {
+	t := transform.Chain(norm.NFD, cases.Fold())
+	p, _, _ = transform.String(t, p)
+	return p
+}
+
+// canonicalizeOS is a no-op on platforms without 8.3 short-form aliases.
+func canonicalizeOS(p string) string {
+	return p
+}

--- a/path_other.go
+++ b/path_other.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !darwin
 
 package fsnotify
 

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -499,9 +499,9 @@ func TestSymlinkDeduplicates(t *testing.T) {
 	}
 }
 
-func TestAddCaseInsensitiveOnWindows(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows-only")
+func TestAddCaseInsensitive(t *testing.T) {
+	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
+		t.Skip("It looks that your file system is case sensitive, so this test is not applicable")
 	}
 	dir := tempDir(t)
 	w := newWatcher(t)
@@ -515,6 +515,75 @@ func TestAddCaseInsensitiveOnWindows(t *testing.T) {
 	}
 	if err := w.Remove(upper); err != nil {
 		t.Errorf("Remove(uppercased) = %v, want nil", err)
+	}
+}
+
+func TestAddSharpS(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("This test is only applicable on macOS")
+	}
+
+	parent := tempDir(t)
+	w := newWatcher(t)
+
+	dir := filepath.Join(parent, "ß") // LATIN SMALL LETTER SHARP S
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := w.Add(dir, All); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	dir = filepath.Join(parent, "ẞ") // LATIN CAPITAL LETTER SHARP S
+	if err := os.Mkdir(dir, 0o755); !errors.Is(err, os.ErrExist) {
+		t.Errorf("Mkdir(ẞ) = %v, want os.ErrExist", err)
+	}
+	if err := w.Add(dir, All); !errors.Is(err, ErrAlreadyAdded) {
+		t.Errorf("Add(ẞ) = %v, want ErrAlreadyAdded", err)
+	}
+
+	dir = filepath.Join(parent, "ss")
+	if err := os.Mkdir(dir, 0o755); !errors.Is(err, os.ErrExist) {
+		t.Errorf("Mkdir(ss) = %v, want os.ErrExist", err)
+	}
+	if err := w.Add(dir, All); !errors.Is(err, ErrAlreadyAdded) {
+		t.Errorf("Add(ss) = %v, want ErrAlreadyAdded", err)
+	}
+
+	dir = filepath.Join(parent, "SS")
+	if err := os.Mkdir(dir, 0o755); !errors.Is(err, os.ErrExist) {
+		t.Errorf("Mkdir(SS) = %v, want os.ErrExist", err)
+	}
+	if err := w.Add(dir, All); !errors.Is(err, ErrAlreadyAdded) {
+		t.Errorf("Add(SS) = %v, want ErrAlreadyAdded", err)
+	}
+}
+
+func TestAddUnicodeNormalization(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("This test is only applicable on macOS")
+	}
+
+	parent := tempDir(t)
+	w := newWatcher(t)
+
+	dir := filepath.Join(parent, "\u304C") // HIRAGANA LETTER GA (U+304C) in NFC
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := w.Add(dir, All); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	dir = filepath.Join(parent, "\u304B\u3099") // HIRAGANA LETTER GA in NFD (U+304C decomposes to U+304B + U+3099)
+	if err := os.Mkdir(dir, 0o755); !errors.Is(err, os.ErrExist) {
+		t.Errorf("Mkdir(\u304B\u3099) = %v, want os.ErrExist", err)
+	}
+	if err := w.Add(dir, All); !errors.Is(err, ErrAlreadyAdded) {
+		t.Errorf("Add(\u304B\u3099) = %v, want ErrAlreadyAdded", err)
+	}
+	if err := w.Remove(dir); err != nil {
+		t.Errorf("Remove(\u304B\u3099) = %v, want nil", err)
 	}
 }
 


### PR DESCRIPTION
Improved case-insensitive filesystem handling on macOS with Unicode normalization for more reliable path comparisons.

I added test case for Sharp S.
Case-insensitive comparison of “ß” and “ẞ” (Sharp S) is special.
They also match “ss” and “SS”.

I also add test case for HIRAGANA LETTER GA.
HIRAGANA LETTER GA has two representations in Unicode.

- HIRAGANA LETTER GA (U+304C) in NFC
- HIRAGANA LETTER GA in NFD (U+304C decomposes to U+304B + U+3099)

APFS does not distinguish between the two.
