### PR TITLE
Surface Create for nested dirs under AddRecursive (#29)

### DIFF
--- a/watcher_freebsd.go
+++ b/watcher_freebsd.go
@@ -97,6 +97,15 @@ func (w *Watcher) Add(path string, op Op) error {
 // subdirectories created inside path are watched automatically; removed
 // subdirectories are dropped on NOTE_DELETE. Returns ErrAlreadyAdded
 // if path is already registered.
+//
+// When a directory is created underneath an AddRecursive root, the
+// watcher attaches a watch to it and walks it for any pre-existing
+// descendants (for example after mkdir -p or after a populated subtree
+// is moved in) so that their Create events are not lost. If another
+// process concurrently creates entries inside the new directory in the
+// brief window between watch attachment and the walk, the same Create
+// may be reported twice; consumers should handle duplicate Create
+// events idempotently.
 func (w *Watcher) AddRecursive(path string, op Op) error {
 	return w.add(path, op, true)
 }
@@ -125,7 +134,10 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 	}
 	root.recursive = recursive
 	if root.isDir {
-		w.populateChildrenLocked(root, recursive)
+		// Pre-existing descendants at registration time are intentionally
+		// silent — the user just asked us to start watching, so they are
+		// not new from the user's point of view.
+		_ = w.populateChildrenLocked(root, recursive)
 	}
 	w.roots[key] = root
 	return nil
@@ -133,12 +145,16 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 
 // populateChildrenLocked scans dir and registers a watch for every
 // immediate child. When recursive, descends into each child directory
-// so the entire subtree is covered. Caller holds w.mu.
-func (w *Watcher) populateChildrenLocked(dir *kqWatch, recursive bool) {
+// so the entire subtree is covered. Returns the absolute paths of
+// every entry (immediate children and descendants when recursive) that
+// was newly added on this call so callers can synthesize Create events
+// for them. Caller holds w.mu.
+func (w *Watcher) populateChildrenLocked(dir *kqWatch, recursive bool) []string {
 	entries, err := os.ReadDir(dir.path)
 	if err != nil {
-		return
+		return nil
 	}
+	var added []string
 	for _, e := range entries {
 		childPath := filepath.Join(dir.path, e.Name())
 		child, err := w.openLocked(childPath, dir.op, dir)
@@ -146,10 +162,12 @@ func (w *Watcher) populateChildrenLocked(dir *kqWatch, recursive bool) {
 			continue
 		}
 		dir.children[e.Name()] = child
+		added = append(added, childPath)
 		if recursive && child.isDir {
-			w.populateChildrenLocked(child, true)
+			added = append(added, w.populateChildrenLocked(child, true)...)
 		}
 	}
+	return added
 }
 
 // Remove unregisters path. Returns ErrNotAdded if path is not registered.
@@ -362,7 +380,10 @@ func (w *Watcher) diffDir(dir *kqWatch, requested Op) {
 		dir.children[name] = child
 		added = append(added, childPath)
 		if recursive && child.isDir {
-			w.populateChildrenLocked(child, true)
+			// mkdir -p (or a populated subtree moved in) lands all the
+			// nested entries before NOTE_WRITE reaches us; report them
+			// instead of attaching watches silently.
+			added = append(added, w.populateChildrenLocked(child, true)...)
 		}
 	}
 	w.mu.Unlock()

--- a/watcher_linux.go
+++ b/watcher_linux.go
@@ -79,6 +79,15 @@ func (w *Watcher) Add(path string, op Op) error {
 // subdirectories created inside path are watched automatically; subtrees
 // that disappear are dropped via the kernel's IN_IGNORED notification.
 // Returns ErrAlreadyAdded if path is already registered.
+//
+// When a directory is created underneath an AddRecursive root, the
+// watcher attaches an inotify watch to it and walks it for any
+// pre-existing descendants (for example after mkdir -p or after a
+// populated subtree is moved in) so that their Create events are not
+// lost. If another process concurrently creates entries inside the new
+// directory in the brief window between watch attachment and the walk,
+// the same Create may be reported twice; consumers should handle
+// duplicate Create events idempotently.
 func (w *Watcher) AddRecursive(path string, op Op) error {
 	return w.add(path, op, true)
 }
@@ -105,7 +114,10 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 		return fmt.Errorf("fsnotify: add %s: %w", abs, err)
 	}
 	if recursive {
-		w.walkAndAddLocked(abs, op, key)
+		// Pre-existing descendants at registration time are intentionally
+		// silent — the user just asked us to start watching, so they are
+		// not new from the user's point of view.
+		_ = w.walkAndAddLocked(abs, op, key)
 	}
 	return nil
 }
@@ -125,9 +137,12 @@ func (w *Watcher) addWatchLocked(abs string, op Op, rootKey string, recursive bo
 }
 
 // walkAndAddLocked walks root and adds an inotify watch for every
-// subdirectory. Best-effort: unreadable subtrees are skipped silently.
-// Caller holds w.mu.
-func (w *Watcher) walkAndAddLocked(root string, op Op, rootKey string) {
+// subdirectory. Returns the absolute paths of subdirectories that were
+// newly watched on this call (root itself excluded; entries that were
+// already watched are skipped). Best-effort: unreadable subtrees are
+// skipped silently. Caller holds w.mu.
+func (w *Watcher) walkAndAddLocked(root string, op Op, rootKey string) []string {
+	var added []string
 	_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
@@ -141,9 +156,12 @@ func (w *Watcher) walkAndAddLocked(root string, op Op, rootKey string) {
 		if _, dup := w.watches[pathKey(p)]; dup {
 			return nil
 		}
-		_, _ = w.addWatchLocked(p, op, rootKey, false)
+		if _, err := w.addWatchLocked(p, op, rootKey, false); err == nil {
+			added = append(added, p)
+		}
 		return nil
 	})
+	return added
 }
 
 // Remove unregisters path. For an AddRecursive registration, every
@@ -290,7 +308,14 @@ func (w *Watcher) dispatch(wd int32, mask uint32, name string) {
 
 	// A new directory under a recursive root needs its own watch so we
 	// keep seeing events as the tree grows. Walk into it in case it
-	// already contains pre-existing children (e.g. it was renamed in).
+	// already contains pre-existing children (e.g. mkdir -p, or a
+	// populated subtree renamed in) and synthesize Create for each so
+	// they are not silently lost — inotify only reports the outermost
+	// directory in that situation. A concurrent writer creating entries
+	// in the brief window between watch attachment and the walk may
+	// cause the same Create to be reported twice; this is documented on
+	// AddRecursive.
+	var synth []string
 	if recursive && mask&syscall.IN_CREATE != 0 && mask&syscall.IN_ISDIR != 0 {
 		var addErr error
 		w.mu.Lock()
@@ -299,7 +324,7 @@ func (w *Watcher) dispatch(wd int32, mask uint32, name string) {
 				if _, err := w.addWatchLocked(full, lw.op, rootKey, false); err != nil {
 					addErr = err
 				} else {
-					w.walkAndAddLocked(full, lw.op, rootKey)
+					synth = w.walkAndAddLocked(full, lw.op, rootKey)
 				}
 			}
 		}
@@ -310,10 +335,14 @@ func (w *Watcher) dispatch(wd int32, mask uint32, name string) {
 	}
 
 	op := maskToOp(mask) & lw.op
-	if op == 0 {
-		return
+	if op != 0 {
+		w.sendEvent(Event{Name: full, Op: op})
 	}
-	w.sendEvent(Event{Name: full, Op: op})
+	if lw.op.Has(Create) {
+		for _, p := range synth {
+			w.sendEvent(Event{Name: p, Op: Create})
+		}
+	}
 }
 
 func (w *Watcher) sendEvent(e Event) {

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -661,6 +661,65 @@ func TestAddRecursiveNewDir(t *testing.T) {
 	}
 }
 
+// TestAddRecursiveDeepMkdir exercises issue #29: when MkdirAll creates a
+// nested tree under a recursive root, every level should surface a
+// Create event, not just the outermost directory. Inotify only reports
+// the top dir natively, so the watcher must walk and synthesize Creates
+// for the descendants; FSEvents and ReadDirectoryChangesW emit them
+// natively. The test tolerates duplicates because concurrent activity
+// in the brief race window can legitimately deliver the same Create
+// twice (documented on AddRecursive).
+func TestAddRecursiveDeepMkdir(t *testing.T) {
+	root := tempDir(t)
+
+	w := newWatcher(t)
+	if err := w.AddRecursive(root, All); err != nil {
+		t.Fatalf("AddRecursive: %v", err)
+	}
+
+	a := filepath.Join(root, "a")
+	b := filepath.Join(a, "b")
+	c := filepath.Join(b, "c")
+	if err := os.MkdirAll(c, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	want := map[string]bool{a: false, b: false, c: false}
+	deadline := time.NewTimer(eventTimeout)
+	defer deadline.Stop()
+	for {
+		all := true
+		for _, seen := range want {
+			if !seen {
+				all = false
+				break
+			}
+		}
+		if all {
+			return
+		}
+		select {
+		case ev, ok := <-w.Events:
+			if !ok {
+				t.Fatalf("Events channel closed early")
+			}
+			if _, tracked := want[ev.Name]; tracked && ev.Op.Has(Create) {
+				want[ev.Name] = true
+			}
+		case err := <-w.Errors:
+			t.Fatalf("unexpected error: %v", err)
+		case <-deadline.C:
+			missing := []string{}
+			for p, seen := range want {
+				if !seen {
+					missing = append(missing, p)
+				}
+			}
+			t.Fatalf("timeout; missing Create for %v", missing)
+		}
+	}
+}
+
 func TestAddRecursiveRemoveDropsSubtree(t *testing.T) {
 	root := tempDir(t)
 	nested := filepath.Join(root, "a", "b")


### PR DESCRIPTION
Fixes #29.

`mkdir -p a/b/c` underneath an `AddRecursive` root previously delivered a Create event only for the outermost directory. inotify cannot fire `IN_CREATE` for `b` or `c` because their parent watches were not yet attached when the kernel processed the creates; on FreeBSD the same is true under kqueue, where `NOTE_WRITE` on the parent triggers a diff that silently attaches watches to every newly discovered descendant. The walk-and-add logic was correctly attaching watches but never surfacing the discovered entries as events, so the user-visible stream missed the inner levels.

This change makes `walkAndAddLocked` (Linux) and `populateChildrenLocked` (FreeBSD) return the absolute paths of every directory newly watched on a given call. The auto-watch dispatch path then synthesizes a `Create` event for each discovered descendant when the registration includes `Create`. The initial `AddRecursive` call intentionally discards the slice so pre-existing descendants at registration time stay silent — they are not new from the caller's point of view.

The walk-then-synthesize approach can deliver the same `Create` twice when another process creates entries inside the new directory in the small window between watch attachment and the walk completing. Trading occasional duplicates for guaranteed delivery is preferable to a TTL-based dedupe, which would convert that loud failure into a silent missed event (for example a quick remove-then-recreate inside the TTL would be suppressed). The duplicate behavior is documented on `AddRecursive` so consumers can dedupe if they need to.

macOS FSEvents (`kFSEventStreamCreateFlagFileEvents`) and Windows `ReadDirectoryChangesW` with `bWatchSubtree` already report every nested Create natively, so those backends need no change.

A platform-agnostic test, `TestAddRecursiveDeepMkdir`, runs `MkdirAll` under a recursive root and asserts that every level emits a Create. It tolerates duplicates to match the documented contract.