### PR TITLE
Optimize Op.String()

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -4,6 +4,7 @@ package fsnotify
 import (
 	"errors"
 	"fmt"
+	"math/bits"
 	"strings"
 )
 
@@ -33,26 +34,47 @@ func (op Op) Has(target Op) bool {
 
 // String returns a human-readable representation such as "CREATE|WRITE".
 func (op Op) String() string {
+	op &= All
 	if op == 0 {
 		return ""
 	}
-	var parts []string
+
+	// Fast path for single-bit ops, which are common in practice and avoid allocations.
+	n := bits.OnesCount32(uint32(op))
+	if n == 1 {
+		switch op {
+		case Create:
+			return "CREATE"
+		case Write:
+			return "WRITE"
+		case Remove:
+			return "REMOVE"
+		case Rename:
+			return "RENAME"
+		case Chmod:
+			return "CHMOD"
+		}
+	}
+
+	// Slow path for multiple bits, which allocates a string builder.
+	var buf strings.Builder
+	buf.Grow(n * 7) // "CREATE" is 6 chars + '|' separator
 	if op.Has(Create) {
-		parts = append(parts, "CREATE")
+		buf.WriteString("|CREATE")
 	}
 	if op.Has(Write) {
-		parts = append(parts, "WRITE")
+		buf.WriteString("|WRITE")
 	}
 	if op.Has(Remove) {
-		parts = append(parts, "REMOVE")
+		buf.WriteString("|REMOVE")
 	}
 	if op.Has(Rename) {
-		parts = append(parts, "RENAME")
+		buf.WriteString("|RENAME")
 	}
 	if op.Has(Chmod) {
-		parts = append(parts, "CHMOD")
+		buf.WriteString("|CHMOD")
 	}
-	return strings.Join(parts, "|")
+	return buf.String()[1:]
 }
 
 // Event represents a single file system change.

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -24,6 +24,25 @@ func TestOpString(t *testing.T) {
 	}
 }
 
+func BenchmarkOpString(b *testing.B) {
+	tests := []Op{
+		0,
+		Create,
+		Create | Write,
+		Create | Write | Remove,
+		Create | Write | Remove | Rename,
+		All,
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.String(), func(b *testing.B) {
+			for b.Loop() {
+				_ = tt.String()
+			}
+		})
+	}
+}
+
 func TestOpHas(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
```plain
goos: darwin
goarch: arm64
pkg: github.com/gofsnotify/fsnotify
cpu: Apple M1 Pro
                                             │   .old.txt   │              .new.txt               │
                                             │    sec/op    │   sec/op     vs base                │
OpString/#00-10                                 2.075n ± 2%   2.070n ± 3%        ~ (p=0.986 n=10)
OpString/CREATE-10                              4.057n ± 0%   2.062n ± 0%  -49.16% (p=0.000 n=10)
OpString/CREATE|WRITE-10                        28.61n ± 1%   17.73n ± 1%  -38.04% (p=0.000 n=10)
OpString/CREATE|WRITE|REMOVE-10                 59.78n ± 0%   19.26n ± 0%  -67.78% (p=0.000 n=10)
OpString/CREATE|WRITE|REMOVE|RENAME-10          67.67n ± 0%   21.08n ± 0%  -68.85% (p=0.000 n=10)
OpString/CREATE|WRITE|REMOVE|RENAME|CHMOD-10   105.15n ± 0%   23.80n ± 1%  -77.37% (p=0.000 n=10)
geomean                                         21.63n        9.492n       -56.12%

                                             │   .old.txt    │               .new.txt               │
                                             │     B/op      │    B/op     vs base                  │
OpString/#00-10                                 0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
OpString/CREATE-10                              0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
OpString/CREATE|WRITE-10                        16.00 ± 0%     16.00 ± 0%        ~ (p=1.000 n=10) ¹
OpString/CREATE|WRITE|REMOVE-10                 88.00 ± 0%     24.00 ± 0%  -72.73% (p=0.000 n=10)
OpString/CREATE|WRITE|REMOVE|RENAME-10          96.00 ± 0%     32.00 ± 0%  -66.67% (p=0.000 n=10)
OpString/CREATE|WRITE|REMOVE|RENAME|CHMOD-10   224.00 ± 0%     48.00 ± 0%  -78.57% (p=0.000 n=10)
geomean                                                    ²               -48.13%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                             │   .old.txt   │               .new.txt               │
                                             │  allocs/op   │ allocs/op   vs base                  │
OpString/#00-10                                0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
OpString/CREATE-10                             0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
OpString/CREATE|WRITE-10                       1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
OpString/CREATE|WRITE|REMOVE-10                2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.000 n=10)
OpString/CREATE|WRITE|REMOVE|RENAME-10         2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.000 n=10)
OpString/CREATE|WRITE|REMOVE|RENAME|CHMOD-10   3.000 ± 0%     1.000 ± 0%  -66.67% (p=0.000 n=10)
geomean                                                   ²               -33.91%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```
