### PR TITLE
linux: remove unnecessary syscall.EINTR check

### DIFF
--- a/watcher_linux.go
+++ b/watcher_linux.go
@@ -234,9 +234,6 @@ func (w *Watcher) readLoop() {
 				return
 			default:
 			}
-			if errors.Is(err, syscall.EINTR) {
-				continue
-			}
 			// os.ErrClosed surfaces when Close calls file.Close().
 			if errors.Is(err, os.ErrClosed) {
 				return


### PR DESCRIPTION
The runtime handles it, so we don't need to check it here.

- [func (f *File) Read(b []byte) (n int, err error)](https://github.com/golang/go/blob/2dc996f71b0ebafb77e64433e58333e049488a3c/src/os/file.go#L144)
- [func (f *File) read(b []byte) (n int, err error)](https://github.com/golang/go/blob/2dc996f71b0ebafb77e64433e58333e049488a3c/src/os/file_posix.go#L29)
- [func (fd *FD) Read(p []byte) (int, error)](https://github.com/golang/go/blob/2dc996f71b0ebafb77e64433e58333e049488a3c/src/internal/poll/fd_unix.go#L161)
- [func ignoringEINTRIO(fn func(fd int, p []byte) (int, error), fd int, p []byte) (int, error)](https://github.com/golang/go/blob/2dc996f71b0ebafb77e64433e58333e049488a3c/src/internal/poll/fd_unix.go#L735-L743)