### PR TITLE
Deprecate this module in favor of github.com/fswatcher/fswatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.7] - 2026-05-18
+
+### Changed
+- Mark this module as deprecated; development continues at `github.com/fswatcher/fswatcher` (#27)
+
 ## [0.0.6] - 2026-05-12
 
 ### Added
@@ -104,7 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Tighten the `Chmod` test for Windows
 - Canonicalize temp directories in tests for cross-platform stability
 
-[Unreleased]: https://github.com/gofsnotify/fsnotify/compare/v0.0.6...HEAD
+[Unreleased]: https://github.com/gofsnotify/fsnotify/compare/v0.0.7...HEAD
+[0.0.7]: https://github.com/gofsnotify/fsnotify/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/gofsnotify/fsnotify/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/gofsnotify/fsnotify/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/gofsnotify/fsnotify/compare/v0.0.3...v0.0.4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # fsnotify
 
+> **Moved.** This project has moved to [`github.com/fswatcher/fswatcher`](https://github.com/fswatcher/fswatcher). The module at `github.com/gofsnotify/fsnotify` is deprecated and will not receive further updates. Please update your imports:
+>
+> ```
+> go get github.com/fswatcher/fswatcher
+> ```
+>
+> See issue [#27](https://github.com/gofsnotify/fsnotify/issues/27) for the background.
+
 [![CI](https://github.com/gofsnotify/fsnotify/actions/workflows/ci.yml/badge.svg)](https://github.com/gofsnotify/fsnotify/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/gofsnotify/fsnotify.svg)](https://pkg.go.dev/github.com/gofsnotify/fsnotify)
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: this module has moved to github.com/fswatcher/fswatcher.
 module github.com/gofsnotify/fsnotify
 
 go 1.25.0


### PR DESCRIPTION
This marks `github.com/gofsnotify/fsnotify` as deprecated ahead of moving the project to `github.com/fswatcher/fswatcher` (see #27).

The `// Deprecated:` directive on the `module` line is the standard signal recognized by `go list -m -u`, `gopls`, and pkg.go.dev, so existing users will see a clear pointer to the new path the next time they run `go get -u` or open the package page. A migration notice is also added to the top of the README, and CHANGELOG gets a `0.0.7` entry.

After merging, tag `v0.0.7` on this commit so the deprecation marker reaches the module proxy; the repository transfer and the module/package rename to `fswatcher` will follow in subsequent changes.