### PR TITLE
Rename module and package to fswatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-05-18
+
+### Changed
+- Rename module path to `github.com/fswatcher/fswatcher` and package to `fswatcher` (#27)
+- Rename `cmd/fsnotify` binary to `cmd/fswatcher`; environment variables passed to `-e CMD` are now `FSWATCHER_PATH` and `FSWATCHER_OP`
+- Error messages now use the `fswatcher: ` prefix (was `fsnotify: `)
+
 ## [0.0.7] - 2026-05-18
 
 ### Changed
@@ -109,11 +116,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Tighten the `Chmod` test for Windows
 - Canonicalize temp directories in tests for cross-platform stability
 
-[Unreleased]: https://github.com/gofsnotify/fsnotify/compare/v0.0.7...HEAD
-[0.0.7]: https://github.com/gofsnotify/fsnotify/compare/v0.0.6...v0.0.7
-[0.0.6]: https://github.com/gofsnotify/fsnotify/compare/v0.0.5...v0.0.6
-[0.0.5]: https://github.com/gofsnotify/fsnotify/compare/v0.0.4...v0.0.5
-[0.0.4]: https://github.com/gofsnotify/fsnotify/compare/v0.0.3...v0.0.4
-[0.0.3]: https://github.com/gofsnotify/fsnotify/compare/v0.0.2...v0.0.3
-[0.0.2]: https://github.com/gofsnotify/fsnotify/compare/v0.0.1...v0.0.2
-[0.0.1]: https://github.com/gofsnotify/fsnotify/releases/tag/v0.0.1
+[Unreleased]: https://github.com/fswatcher/fswatcher/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/fswatcher/fswatcher/compare/v0.0.7...v0.1.0
+[0.0.7]: https://github.com/fswatcher/fswatcher/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/fswatcher/fswatcher/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/fswatcher/fswatcher/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/fswatcher/fswatcher/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/fswatcher/fswatcher/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/fswatcher/fswatcher/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/fswatcher/fswatcher/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -1,22 +1,16 @@
-# fsnotify
+# fswatcher
 
-> **Moved.** This project has moved to [`github.com/fswatcher/fswatcher`](https://github.com/fswatcher/fswatcher). The module at `github.com/gofsnotify/fsnotify` is deprecated and will not receive further updates. Please update your imports:
->
-> ```
-> go get github.com/fswatcher/fswatcher
-> ```
->
-> See issue [#27](https://github.com/gofsnotify/fsnotify/issues/27) for the background.
-
-[![CI](https://github.com/gofsnotify/fsnotify/actions/workflows/ci.yml/badge.svg)](https://github.com/gofsnotify/fsnotify/actions/workflows/ci.yml)
-[![Go Reference](https://pkg.go.dev/badge/github.com/gofsnotify/fsnotify.svg)](https://pkg.go.dev/github.com/gofsnotify/fsnotify)
+[![CI](https://github.com/fswatcher/fswatcher/actions/workflows/ci.yml/badge.svg)](https://github.com/fswatcher/fswatcher/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/fswatcher/fswatcher.svg)](https://pkg.go.dev/github.com/fswatcher/fswatcher)
 
 Cross-platform file system notifications for Go.
+
+> Previously published as `github.com/gofsnotify/fsnotify` (package `fsnotify`). The old path is deprecated and redirects here; update imports and rename `fsnotify.X` to `fswatcher.X`. See [#27](https://github.com/fswatcher/fswatcher/issues/27).
 
 ## Install
 
 ```
-go get github.com/gofsnotify/fsnotify
+go get github.com/fswatcher/fswatcher
 ```
 
 ## Usage
@@ -27,17 +21,17 @@ package main
 import (
 	"log"
 
-	"github.com/gofsnotify/fsnotify"
+	"github.com/fswatcher/fswatcher"
 )
 
 func main() {
-	w, err := fsnotify.NewWatcher()
+	w, err := fswatcher.NewWatcher()
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer w.Close()
 
-	if err := w.Add("/path/to/dir", fsnotify.Create|fsnotify.Write|fsnotify.Remove); err != nil {
+	if err := w.Add("/path/to/dir", fswatcher.Create|fswatcher.Write|fswatcher.Remove); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/fswatcher/main.go
+++ b/cmd/fswatcher/main.go
@@ -1,9 +1,9 @@
-// Command fsnotify watches one or more paths and prints file system
+// Command fswatcher watches one or more paths and prints file system
 // events to stdout, or runs a shell command on each event.
 //
 // Usage:
 //
-//	fsnotify [flags] PATH [PATH...]
+//	fswatcher [flags] PATH [PATH...]
 //
 // Flags:
 //
@@ -11,7 +11,7 @@
 //	-V          verbose log to stderr (registrations, signals, exec exits)
 //	-e CMD      run CMD via the platform shell on every event
 //	            (sh -c on Unix, cmd /C on Windows). The child receives
-//	            FSNOTIFY_PATH and FSNOTIFY_OP in its environment.
+//	            FSWATCHER_PATH and FSWATCHER_OP in its environment.
 //	-json       emit each event as one NDJSON object on stdout instead
 //	            of the default "OP\tPATH" line. Mutually exclusive with -e.
 //
@@ -30,7 +30,7 @@ import (
 	"runtime"
 	"syscall"
 
-	"github.com/gofsnotify/fsnotify"
+	"github.com/fswatcher/fswatcher"
 )
 
 var (
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	log.SetFlags(0)
-	log.SetPrefix("fsnotify: ")
+	log.SetPrefix("fswatcher: ")
 	log.SetOutput(os.Stderr)
 
 	if *execCmd != "" && *jsonOut {
@@ -63,7 +63,7 @@ func main() {
 	}
 	jsonEnc := json.NewEncoder(os.Stdout)
 
-	w, err := fsnotify.NewWatcher()
+	w, err := fswatcher.NewWatcher()
 	if err != nil {
 		log.Fatalf("new watcher: %v", err)
 	}
@@ -74,7 +74,7 @@ func main() {
 		add = w.AddRecursive
 	}
 	for _, p := range paths {
-		if err := add(p, fsnotify.All); err != nil {
+		if err := add(p, fswatcher.All); err != nil {
 			log.Fatalf("add %s: %v", p, err)
 		}
 		if *verbose {
@@ -128,9 +128,9 @@ type jsonEvent struct {
 
 // runCommand executes cmd through the platform's shell so users can
 // pipe, redirect, and use environment variables naturally. The event
-// is exposed via FSNOTIFY_PATH and FSNOTIFY_OP so the command does not
+// is exposed via FSWATCHER_PATH and FSWATCHER_OP so the command does not
 // need to parse anything.
-func runCommand(cmd string, ev fsnotify.Event) {
+func runCommand(cmd string, ev fswatcher.Event) {
 	var c *exec.Cmd
 	if runtime.GOOS == "windows" {
 		c = exec.Command("cmd", "/C", cmd)
@@ -140,8 +140,8 @@ func runCommand(cmd string, ev fsnotify.Event) {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	c.Env = append(os.Environ(),
-		"FSNOTIFY_PATH="+ev.Name,
-		"FSNOTIFY_OP="+ev.Op.String(),
+		"FSWATCHER_PATH="+ev.Name,
+		"FSWATCHER_OP="+ev.Op.String(),
 	)
 	if err := c.Run(); err != nil {
 		if *verbose {

--- a/fswatcher.go
+++ b/fswatcher.go
@@ -1,5 +1,5 @@
-// Package fsnotify provides cross-platform file system change notifications.
-package fsnotify
+// Package fswatcher provides cross-platform file system change notifications.
+package fswatcher
 
 import (
 	"errors"
@@ -94,11 +94,11 @@ func (e Event) String() string {
 // Sentinel errors returned by Watcher methods.
 var (
 	// ErrAlreadyAdded is returned by Add when path is already registered.
-	ErrAlreadyAdded = errors.New("fsnotify: path already added")
+	ErrAlreadyAdded = errors.New("fswatcher: path already added")
 	// ErrNotAdded is returned by Remove when path is not registered.
-	ErrNotAdded = errors.New("fsnotify: path not added")
+	ErrNotAdded = errors.New("fswatcher: path not added")
 	// ErrClosed is returned by methods called on a closed Watcher.
-	ErrClosed = errors.New("fsnotify: watcher closed")
+	ErrClosed = errors.New("fswatcher: watcher closed")
 	// ErrUnsupported is returned by NewWatcher on platforms without a backend.
-	ErrUnsupported = errors.New("fsnotify: platform not supported")
+	ErrUnsupported = errors.New("fswatcher: platform not supported")
 )

--- a/fswatcher_test.go
+++ b/fswatcher_test.go
@@ -1,4 +1,4 @@
-package fsnotify
+package fswatcher
 
 import "testing"
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,4 @@
-// Deprecated: this module has moved to github.com/fswatcher/fswatcher.
-module github.com/gofsnotify/fsnotify
+module github.com/fswatcher/fswatcher
 
 go 1.25.0
 

--- a/path.go
+++ b/path.go
@@ -1,4 +1,4 @@
-package fsnotify
+package fswatcher
 
 import "path/filepath"
 

--- a/path_darwin.go
+++ b/path_darwin.go
@@ -1,6 +1,6 @@
 //go:build darwin
 
-package fsnotify
+package fswatcher
 
 import (
 	"golang.org/x/text/cases"

--- a/path_other.go
+++ b/path_other.go
@@ -1,6 +1,6 @@
 //go:build !windows && !darwin
 
-package fsnotify
+package fswatcher
 
 // pathKey returns p unchanged on platforms with case-sensitive paths.
 func pathKey(p string) string {

--- a/path_windows.go
+++ b/path_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package fsnotify
+package fswatcher
 
 import (
 	"strings"

--- a/path_windows_test.go
+++ b/path_windows_test.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package fsnotify
+package fswatcher
 
 import (
 	"strings"

--- a/watcher_bench_test.go
+++ b/watcher_bench_test.go
@@ -1,4 +1,4 @@
-package fsnotify
+package fswatcher
 
 import (
 	"os"

--- a/watcher_darwin.go
+++ b/watcher_darwin.go
@@ -1,6 +1,6 @@
 //go:build darwin
 
-package fsnotify
+package fswatcher
 
 import (
 	"fmt"
@@ -88,15 +88,15 @@ func initFSEvents() error {
 func doInitFSEvents() error {
 	cf, err := purego.Dlopen("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 	if err != nil {
-		return fmt.Errorf("fsnotify: load CoreFoundation: %w", err)
+		return fmt.Errorf("fswatcher: load CoreFoundation: %w", err)
 	}
 	cs, err := purego.Dlopen("/System/Library/Frameworks/CoreServices.framework/CoreServices", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 	if err != nil {
-		return fmt.Errorf("fsnotify: load CoreServices: %w", err)
+		return fmt.Errorf("fswatcher: load CoreServices: %w", err)
 	}
 	ls, err := purego.Dlopen("/usr/lib/libSystem.B.dylib", purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 	if err != nil {
-		return fmt.Errorf("fsnotify: load libSystem: %w", err)
+		return fmt.Errorf("fswatcher: load libSystem: %w", err)
 	}
 
 	purego.RegisterLibFunc(&_cfStringCreateWithCString, cf, "CFStringCreateWithCString")
@@ -116,7 +116,7 @@ func doInitFSEvents() error {
 
 	sym, err := purego.Dlsym(cf, "kCFTypeArrayCallBacks")
 	if err != nil {
-		return fmt.Errorf("fsnotify: lookup kCFTypeArrayCallBacks: %w", err)
+		return fmt.Errorf("fswatcher: lookup kCFTypeArrayCallBacks: %w", err)
 	}
 	cfTypeArrayCallBacks = sym
 
@@ -210,7 +210,7 @@ func NewWatcher() (*Watcher, error) {
 		return nil, err
 	}
 
-	queue := _dispatchQueueCreate("github.com/gofsnotify/fsnotify\x00", 0)
+	queue := _dispatchQueueCreate("github.com/fswatcher/fswatcher\x00", 0)
 
 	events := make(chan Event, 64)
 	errors := make(chan error, 8)
@@ -278,7 +278,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 	}
 	abs, err := canonicalize(path)
 	if err != nil {
-		return fmt.Errorf("fsnotify: add %s: %w", path, err)
+		return fmt.Errorf("fswatcher: add %s: %w", path, err)
 	}
 	key := pathKey(abs)
 
@@ -298,7 +298,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 
 	stream, err := w.createStreamLocked(abs)
 	if err != nil {
-		return fmt.Errorf("fsnotify: add %s: %w", abs, err)
+		return fmt.Errorf("fswatcher: add %s: %w", abs, err)
 	}
 	w.streams[key] = &fsStream{
 		stream:    stream,
@@ -347,7 +347,7 @@ func (w *Watcher) createStreamLocked(path string) (uintptr, error) {
 func (w *Watcher) Remove(path string) error {
 	abs, err := canonicalize(path)
 	if err != nil {
-		return fmt.Errorf("fsnotify: remove %s: %w", path, err)
+		return fmt.Errorf("fswatcher: remove %s: %w", path, err)
 	}
 	key := pathKey(abs)
 
@@ -444,7 +444,7 @@ func handleFSEventsCallback(clientInfo uintptr, n int, pathsPtr, flagsPtr unsafe
 		}
 
 		if f&fseMustScanSubs != 0 {
-			w.sendError(fmt.Errorf("fsnotify: events may have been dropped for %s", p))
+			w.sendError(fmt.Errorf("fswatcher: events may have been dropped for %s", p))
 		}
 
 		r, ok := matchRegistration(p, regs)

--- a/watcher_freebsd.go
+++ b/watcher_freebsd.go
@@ -1,6 +1,6 @@
 //go:build freebsd
 
-package fsnotify
+package fswatcher
 
 import (
 	"errors"
@@ -116,7 +116,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 	}
 	abs, err := canonicalize(path)
 	if err != nil {
-		return fmt.Errorf("fsnotify: add %s: %w", path, err)
+		return fmt.Errorf("fswatcher: add %s: %w", path, err)
 	}
 	key := pathKey(abs)
 
@@ -130,7 +130,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 	}
 	root, err := w.openLocked(abs, op, nil)
 	if err != nil {
-		return fmt.Errorf("fsnotify: add %s: %w", abs, err)
+		return fmt.Errorf("fswatcher: add %s: %w", abs, err)
 	}
 	root.recursive = recursive
 	if root.isDir {
@@ -174,7 +174,7 @@ func (w *Watcher) populateChildrenLocked(dir *kqWatch, recursive bool) []string 
 func (w *Watcher) Remove(path string) error {
 	abs, err := canonicalize(path)
 	if err != nil {
-		return fmt.Errorf("fsnotify: remove %s: %w", path, err)
+		return fmt.Errorf("fswatcher: remove %s: %w", path, err)
 	}
 	key := pathKey(abs)
 
@@ -380,7 +380,7 @@ func (w *Watcher) diffDir(dir *kqWatch, requested Op) {
 		added = append(added, childPath)
 		child, err := w.openLocked(childPath, requested, dir)
 		if err != nil {
-			registerErrs = append(registerErrs, fmt.Errorf("fsnotify: register %s: %w", childPath, err))
+			registerErrs = append(registerErrs, fmt.Errorf("fswatcher: register %s: %w", childPath, err))
 			continue
 		}
 		dir.children[name] = child

--- a/watcher_linux.go
+++ b/watcher_linux.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package fsnotify
+package fswatcher
 
 import (
 	"errors"
@@ -98,7 +98,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 	}
 	abs, err := canonicalize(path)
 	if err != nil {
-		return fmt.Errorf("fsnotify: add %s: %w", path, err)
+		return fmt.Errorf("fswatcher: add %s: %w", path, err)
 	}
 	key := pathKey(abs)
 
@@ -111,7 +111,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 		return ErrAlreadyAdded
 	}
 	if _, err := w.addWatchLocked(abs, op, key, recursive); err != nil {
-		return fmt.Errorf("fsnotify: add %s: %w", abs, err)
+		return fmt.Errorf("fswatcher: add %s: %w", abs, err)
 	}
 	if recursive {
 		// Pre-existing descendants at registration time are intentionally
@@ -170,7 +170,7 @@ func (w *Watcher) walkAndAddLocked(root string, op Op, rootKey string) []string 
 func (w *Watcher) Remove(path string) error {
 	abs, err := canonicalize(path)
 	if err != nil {
-		return fmt.Errorf("fsnotify: remove %s: %w", path, err)
+		return fmt.Errorf("fswatcher: remove %s: %w", path, err)
 	}
 	key := pathKey(abs)
 
@@ -327,7 +327,7 @@ func (w *Watcher) dispatch(wd int32, mask uint32, name string) {
 		}
 		w.mu.Unlock()
 		if addErr != nil {
-			w.sendError(fmt.Errorf("fsnotify: auto-watch %s: %w", full, addErr))
+			w.sendError(fmt.Errorf("fswatcher: auto-watch %s: %w", full, addErr))
 		}
 	}
 

--- a/watcher_other.go
+++ b/watcher_other.go
@@ -1,6 +1,6 @@
 //go:build !linux && !windows && !darwin && !freebsd
 
-package fsnotify
+package fswatcher
 
 // Watcher is a no-op placeholder on platforms without a backend.
 type Watcher struct {

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1,4 +1,4 @@
-package fsnotify
+package fswatcher
 
 import (
 	"errors"
@@ -154,7 +154,7 @@ func TestKqueueCreateReportsChildRegistrationFailure(t *testing.T) {
 			if !ok {
 				t.Fatalf("Errors channel closed early")
 			}
-			if strings.Contains(err.Error(), "fsnotify: register "+target+":") {
+			if strings.Contains(err.Error(), "fswatcher: register "+target+":") {
 				sawRegisterErr = true
 			}
 		case <-deadline.C:

--- a/watcher_windows.go
+++ b/watcher_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package fsnotify
+package fswatcher
 
 import (
 	"errors"
@@ -106,7 +106,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 	}
 	abs, err := canonicalize(path)
 	if err != nil {
-		return fmt.Errorf("fsnotify: add %s: %w", path, err)
+		return fmt.Errorf("fswatcher: add %s: %w", path, err)
 	}
 	cmpKey := pathKey(abs)
 
@@ -123,7 +123,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 
 	pathPtr, err := windows.UTF16PtrFromString(abs)
 	if err != nil {
-		return fmt.Errorf("fsnotify: add %s: %w", abs, err)
+		return fmt.Errorf("fswatcher: add %s: %w", abs, err)
 	}
 	handle, err := windows.CreateFile(
 		pathPtr,
@@ -135,13 +135,13 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 		0,
 	)
 	if err != nil {
-		return fmt.Errorf("fsnotify: add %s: %w", abs, err)
+		return fmt.Errorf("fswatcher: add %s: %w", abs, err)
 	}
 	w.nextKey++
 	key := w.nextKey
 	if _, err := windows.CreateIoCompletionPort(handle, w.port, key, 0); err != nil {
 		windows.CloseHandle(handle)
-		return fmt.Errorf("fsnotify: add %s: %w", abs, err)
+		return fmt.Errorf("fswatcher: add %s: %w", abs, err)
 	}
 
 	ww := &winWatch{
@@ -153,7 +153,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 	}
 	if err := ww.startRead(); err != nil {
 		windows.CloseHandle(handle)
-		return fmt.Errorf("fsnotify: add %s: %w", abs, err)
+		return fmt.Errorf("fswatcher: add %s: %w", abs, err)
 	}
 	w.watches[key] = ww
 	return nil
@@ -163,7 +163,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 func (w *Watcher) Remove(path string) error {
 	abs, err := canonicalize(path)
 	if err != nil {
-		return fmt.Errorf("fsnotify: remove %s: %w", path, err)
+		return fmt.Errorf("fswatcher: remove %s: %w", path, err)
 	}
 	cmpKey := pathKey(abs)
 
@@ -176,7 +176,7 @@ func (w *Watcher) Remove(path string) error {
 		if pathKey(ww.path) == cmpKey {
 			delete(w.watches, k)
 			if err := windows.CloseHandle(ww.handle); err != nil {
-				return fmt.Errorf("fsnotify: remove %s: %w", abs, err)
+				return fmt.Errorf("fswatcher: remove %s: %w", abs, err)
 			}
 			return nil
 		}


### PR DESCRIPTION
Follow-up to the repository transfer in #27 and the deprecation release in #36/v0.0.7.

This switches the module path in `go.mod` to `github.com/fswatcher/fswatcher`, renames the package identifier from `fsnotify` to `fswatcher` across every source file, updates error-message prefixes and the FSEvents dispatch-queue label, and moves the CLI from `cmd/fsnotify` to `cmd/fswatcher`. The env vars surfaced to `-e CMD` rename to `FSWATCHER_PATH` and `FSWATCHER_OP` so they match the new identifier. README badges and the install/usage snippets are pointed at the new path, and the deprecation line that was added on `v0.0.7` is removed because that marker now lives on the prior tag.

Existing users will need to update imports from `github.com/gofsnotify/fsnotify` to `github.com/fswatcher/fswatcher` and rename `fsnotify.X` to `fswatcher.X`. Pre-rename tags remain reachable at their old paths via GitHub's redirect.

After merging, tag `v0.1.0` (minor bump signals the breaking import change while the project is still 0.x).