### PR TITLE
Export Canonicalize so callers can align roots with Event.Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ func main() {
 - `(*Watcher).Close() error` — stops the watcher and closes the channels.
 - `(*Watcher).Events <-chan Event` — receives change notifications.
 - `(*Watcher).Errors <-chan error` — receives non-fatal errors.
+- `Canonicalize(path string) (string, error)` — returns the form fswatcher uses internally for `Add`, `Remove`, and `Event.Name`. Use it to align a watched root with the paths in event names, for example when computing relative paths or applying an ignore list.
 
 Paths are canonicalized (absolute, cleaned, with symlinks resolved when the target exists; on Windows 8.3 short forms are expanded and case is folded), so two spellings of the same path dedupe and `Event.Name` is always returned in canonical form.
 

--- a/path.go
+++ b/path.go
@@ -2,12 +2,22 @@ package fswatcher
 
 import "path/filepath"
 
-// canonicalize returns the absolute, cleaned form of p so that paths
-// passed to Add and Remove compare consistently regardless of the form
-// the caller used (relative, with redundant separators, with `.`/`..`,
-// or via symbolic links). When the target exists, symlinks are
-// resolved so two paths reaching the same inode dedupe.
-func canonicalize(p string) (string, error) {
+// Canonicalize returns the same form that the watcher uses internally
+// for [Watcher.Add], [Watcher.Remove], and [Event.Name]: an absolute,
+// cleaned path with OS-specific normalization applied (on Windows, 8.3
+// short forms are expanded and case is folded; on macOS, the
+// `/private` prefix on `/var` and `/tmp` is preserved as returned by
+// the system). When the target exists, symlinks are resolved so two
+// paths reaching the same inode dedupe; when it does not exist, the
+// cleaned absolute path is returned as-is.
+//
+// Callers that need to compute paths relative to a watched root
+// (for example, to apply an ignore list to [Event.Name]) should pass
+// the root through Canonicalize first so the prefix matches.
+//
+// The returned error comes from [filepath.Abs] and indicates the
+// working directory could not be determined.
+func Canonicalize(p string) (string, error) {
 	abs, err := filepath.Abs(p)
 	if err != nil {
 		return "", err

--- a/path_windows_test.go
+++ b/path_windows_test.go
@@ -12,9 +12,9 @@ import (
 func TestCanonicalizeExpandsShortPath(t *testing.T) {
 	// t.TempDir() may already mix 8.3 and long components on CI runners,
 	// so fully canonicalize first to get the expected long form.
-	long, err := canonicalize(t.TempDir())
+	long, err := Canonicalize(t.TempDir())
 	if err != nil {
-		t.Fatalf("canonicalize(TempDir): %v", err)
+		t.Fatalf("Canonicalize(TempDir): %v", err)
 	}
 
 	longPtr, err := syscall.UTF16PtrFromString(long)
@@ -31,12 +31,12 @@ func TestCanonicalizeExpandsShortPath(t *testing.T) {
 		t.Skip("temp dir has no distinct 8.3 short form")
 	}
 
-	got, err := canonicalize(short)
+	got, err := Canonicalize(short)
 	if err != nil {
-		t.Fatalf("canonicalize: %v", err)
+		t.Fatalf("Canonicalize: %v", err)
 	}
 	if !strings.EqualFold(got, long) {
-		t.Errorf("canonicalize(%q) = %q, want %q", short, got, long)
+		t.Errorf("Canonicalize(%q) = %q, want %q", short, got, long)
 	}
 }
 

--- a/watcher_darwin.go
+++ b/watcher_darwin.go
@@ -276,7 +276,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 	if op == 0 {
 		op = All
 	}
-	abs, err := canonicalize(path)
+	abs, err := Canonicalize(path)
 	if err != nil {
 		return fmt.Errorf("fswatcher: add %s: %w", path, err)
 	}
@@ -345,7 +345,7 @@ func (w *Watcher) createStreamLocked(path string) (uintptr, error) {
 
 // Remove unregisters path. Returns ErrNotAdded if path is not registered.
 func (w *Watcher) Remove(path string) error {
-	abs, err := canonicalize(path)
+	abs, err := Canonicalize(path)
 	if err != nil {
 		return fmt.Errorf("fswatcher: remove %s: %w", path, err)
 	}
@@ -439,7 +439,7 @@ func handleFSEventsCallback(clientInfo uintptr, n int, pathsPtr, flagsPtr unsafe
 		p := goString(cStr)
 		f := *(*uint32)(unsafe.Add(flagsPtr, uintptr(i)*4))
 
-		if abs, err := canonicalize(p); err == nil {
+		if abs, err := Canonicalize(p); err == nil {
 			p = abs
 		}
 

--- a/watcher_freebsd.go
+++ b/watcher_freebsd.go
@@ -114,7 +114,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 	if op == 0 {
 		op = All
 	}
-	abs, err := canonicalize(path)
+	abs, err := Canonicalize(path)
 	if err != nil {
 		return fmt.Errorf("fswatcher: add %s: %w", path, err)
 	}
@@ -172,7 +172,7 @@ func (w *Watcher) populateChildrenLocked(dir *kqWatch, recursive bool) []string 
 
 // Remove unregisters path. Returns ErrNotAdded if path is not registered.
 func (w *Watcher) Remove(path string) error {
-	abs, err := canonicalize(path)
+	abs, err := Canonicalize(path)
 	if err != nil {
 		return fmt.Errorf("fswatcher: remove %s: %w", path, err)
 	}

--- a/watcher_linux.go
+++ b/watcher_linux.go
@@ -96,7 +96,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 	if op == 0 {
 		op = All
 	}
-	abs, err := canonicalize(path)
+	abs, err := Canonicalize(path)
 	if err != nil {
 		return fmt.Errorf("fswatcher: add %s: %w", path, err)
 	}
@@ -168,7 +168,7 @@ func (w *Watcher) walkAndAddLocked(root string, op Op, rootKey string) []string 
 // descendant watch added on its behalf is dropped too. Returns
 // ErrNotAdded if path is not registered.
 func (w *Watcher) Remove(path string) error {
-	abs, err := canonicalize(path)
+	abs, err := Canonicalize(path)
 	if err != nil {
 		return fmt.Errorf("fswatcher: remove %s: %w", path, err)
 	}

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -13,15 +13,15 @@ import (
 
 const eventTimeout = 10 * time.Second
 
-// tempDir returns TempDir() routed through canonicalize so paths
+// tempDir returns TempDir() routed through Canonicalize so paths
 // emitted by the watcher (which canonicalizes Add input) compare cleanly
 // against expected values regardless of platform-specific symlinks
 // (/var → /private/var on macOS) or 8.3 short forms on Windows.
 func tempDir(tb testing.TB) string {
 	tb.Helper()
-	d, err := canonicalize(tb.TempDir())
+	d, err := Canonicalize(tb.TempDir())
 	if err != nil {
-		tb.Fatalf("canonicalize TempDir: %v", err)
+		tb.Fatalf("Canonicalize TempDir: %v", err)
 	}
 	return d
 }
@@ -379,33 +379,33 @@ func TestCanonicalize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Getwd: %v", err)
 	}
-	// Route the expected value through canonicalize so the test follows
+	// Route the expected value through Canonicalize so the test follows
 	// the same EvalSymlinks pipeline as the implementation. Otherwise
 	// systems where the cwd traverses a symlink (FreeBSD /home →
 	// /usr/home, macOS /var → /private/var) report a spurious mismatch.
-	cwd, err := canonicalize(rawCwd)
+	cwd, err := Canonicalize(rawCwd)
 	if err != nil {
-		t.Fatalf("canonicalize(cwd): %v", err)
+		t.Fatalf("Canonicalize(cwd): %v", err)
 	}
 
-	got, err := canonicalize(".")
+	got, err := Canonicalize(".")
 	if err != nil {
-		t.Fatalf("canonicalize(.): %v", err)
+		t.Fatalf("Canonicalize(.): %v", err)
 	}
 	if got != cwd {
-		t.Errorf("canonicalize(.) = %q, want %q", got, cwd)
+		t.Errorf("Canonicalize(.) = %q, want %q", got, cwd)
 	}
 
-	got, err = canonicalize("foo/../bar")
+	got, err = Canonicalize("foo/../bar")
 	if err != nil {
-		t.Fatalf("canonicalize: %v", err)
+		t.Fatalf("Canonicalize: %v", err)
 	}
-	// When using canonicalize() on a non-existent directory, EvalSymlinks
+	// When using Canonicalize() on a non-existent directory, EvalSymlinks
 	// doesn't work, so symbolic links in the current directory's path
 	// aren't expanded. Therefore, use rawCmd before expansion.
 	want := filepath.Join(rawCwd, "bar")
 	if got != want {
-		t.Errorf("canonicalize(foo/../bar) = %q, want %q", got, want)
+		t.Errorf("Canonicalize(foo/../bar) = %q, want %q", got, want)
 	}
 }
 

--- a/watcher_windows.go
+++ b/watcher_windows.go
@@ -104,7 +104,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 	if op == 0 {
 		op = All
 	}
-	abs, err := canonicalize(path)
+	abs, err := Canonicalize(path)
 	if err != nil {
 		return fmt.Errorf("fswatcher: add %s: %w", path, err)
 	}
@@ -161,7 +161,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 
 // Remove unregisters path. Returns ErrNotAdded if path is not registered.
 func (w *Watcher) Remove(path string) error {
-	abs, err := canonicalize(path)
+	abs, err := Canonicalize(path)
 	if err != nil {
 		return fmt.Errorf("fswatcher: remove %s: %w", path, err)
 	}


### PR DESCRIPTION
Export `canonicalize` as `Canonicalize` so callers can produce the same path form the watcher uses for `Add`, `Remove`, and `Event.Name`.

Motivating use case: watching a root recursively and computing paths relative to that root (for example to apply an ignore list against `Event.Name`) requires the caller's root spelling to match the prefix in event names. Previously there was no way to do this from outside the package without reimplementing the per-OS normalization rule.

The godoc on the new exported function spells out the public contract: what normalization is applied, what happens when the target exists vs. does not exist, and where the returned error comes from.

`canonicalizeOS` remains unexported — it is an implementation detail of the per-OS rule, not part of the contract.