### PR TITLE
fix: resolve conflict between #39 and #40

### DIFF
--- a/watcher_openbsd.go
+++ b/watcher_openbsd.go
@@ -114,7 +114,7 @@ func (w *Watcher) add(path string, op Op, recursive bool) error {
 	if op == 0 {
 		op = All
 	}
-	abs, err := canonicalize(path)
+	abs, err := Canonicalize(path)
 	if err != nil {
 		return fmt.Errorf("fswatcher: add %s: %w", path, err)
 	}
@@ -172,7 +172,7 @@ func (w *Watcher) populateChildrenLocked(dir *kqWatch, recursive bool) []string 
 
 // Remove unregisters path. Returns ErrNotAdded if path is not registered.
 func (w *Watcher) Remove(path string) error {
-	abs, err := canonicalize(path)
+	abs, err := Canonicalize(path)
 	if err != nil {
 		return fmt.Errorf("fswatcher: remove %s: %w", path, err)
 	}


### PR DESCRIPTION
CI on the main branch fails with OpenBSD:

https://github.com/fswatcher/fswatcher/actions/runs/26685260852/job/78652292497

```plain
  go: downloading golang.org/x/sys v0.45.0
  # github.com/fswatcher/fswatcher
  ./watcher_openbsd.go:117:14: undefined: canonicalize
  ./watcher_openbsd.go:175:14: undefined: canonicalize
  # github.com/fswatcher/fswatcher
  # [github.com/fswatcher/fswatcher]
  vet: ./watcher_openbsd.go:117:14: undefined: canonicalize
```
