### PR TITLE
fix: handle EINTR errors in syscalls

### DIFF
--- a/watcher_bsd.go
+++ b/watcher_bsd.go
@@ -152,7 +152,9 @@ func (w *Watcher) Close() error {
 }
 
 func (w *Watcher) openLocked(path string, op Op, parent *kqWatch) (*kqWatch, error) {
-	fd, err := unix.Open(path, unix.O_RDONLY, 0)
+	fd, err := ignoringEINTR2(func() (int, error) {
+		return unix.Open(path, unix.O_RDONLY, 0)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +185,9 @@ func (w *Watcher) registerLocked(ww *kqWatch) error {
 	var ev unix.Kevent_t
 	unix.SetKevent(&ev, ww.fd, unix.EVFILT_VNODE, unix.EV_ADD|unix.EV_CLEAR)
 	ev.Fflags = opToNoteFlags(ww.op, ww.isDir)
-	_, err := unix.Kevent(w.kq, []unix.Kevent_t{ev}, nil, nil)
+	_, err := ignoringEINTR2(func() (int, error) {
+		return unix.Kevent(w.kq, []unix.Kevent_t{ev}, nil, nil)
+	})
 	return err
 }
 
@@ -365,4 +369,29 @@ func opToNoteFlags(op Op, isDir bool) uint32 {
 		f |= unix.NOTE_WRITE
 	}
 	return f
+}
+
+// ignoringEINTR2 calls fn and repeats it if it returns
+// an EINTR error. This is useful for syscalls that can be interrupted by signals.
+func ignoringEINTR2[T any](fn func() (T, error)) (T, error) {
+	for {
+		v, err := fn()
+		if !errors.Is(err, unix.EINTR) {
+			return v, err
+		}
+	}
+}
+
+// suppressEINTR calls fn and returns nil if it returns an EINTR error.
+// This is useful for syscalls that can be interrupted by signals
+// where the caller does not need to distinguish between EINTR and success.
+// For example, when closing a file descriptor,
+// the fd is closed by the kernel even if the syscall is interrupted,
+// so the caller can treat EINTR as success.
+func suppressEINTR(fn func() error) error {
+	err := fn()
+	if errors.Is(err, unix.EINTR) {
+		return nil
+	}
+	return err
 }

--- a/watcher_freebsd.go
+++ b/watcher_freebsd.go
@@ -51,7 +51,9 @@ func NewWatcher() (*Watcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, err = unix.Kevent(kq, []unix.Kevent_t{evCloseRegister}, nil, nil)
+	_, err = ignoringEINTR2(func() (int, error) {
+		return unix.Kevent(kq, []unix.Kevent_t{evCloseRegister}, nil, nil)
+	})
 	if err != nil {
 		unix.Close(kq)
 		return nil, err
@@ -84,10 +86,14 @@ func (w *Watcher) handleEvents(events []unix.Kevent_t) bool {
 }
 
 func (w *Watcher) stopReadLoop() error {
-	_, err := unix.Kevent(w.kq, []unix.Kevent_t{evCloseTrigger}, nil, nil)
+	_, err := ignoringEINTR2(func() (int, error) {
+		return unix.Kevent(w.kq, []unix.Kevent_t{evCloseTrigger}, nil, nil)
+	})
 	return err
 }
 
 func (w *Watcher) closeKq() error {
-	return unix.Close(w.kq)
+	return suppressEINTR(func() error {
+		return unix.Close(w.kq)
+	})
 }

--- a/watcher_openbsd.go
+++ b/watcher_openbsd.go
@@ -49,7 +49,9 @@ func NewWatcher() (*Watcher, error) {
 	// Register the read end of the pipe with kqueue
 	var ev unix.Kevent_t
 	unix.SetKevent(&ev, closePipe[0], unix.EVFILT_READ, unix.EV_ADD|unix.EV_CLEAR)
-	if _, err := unix.Kevent(kq, []unix.Kevent_t{ev}, nil, nil); err != nil {
+	if _, err := ignoringEINTR2(func() (int, error) {
+		return unix.Kevent(kq, []unix.Kevent_t{ev}, nil, nil)
+	}); err != nil {
 		unix.Close(closePipe[0])
 		unix.Close(closePipe[1])
 		unix.Close(kq)
@@ -89,11 +91,15 @@ func (w *Watcher) handleEvents(events []unix.Kevent_t) bool {
 
 func (w *Watcher) stopReadLoop() {
 	// Signal readLoop by writing to the pipe
-	unix.Write(w.closePipe[1], []byte{0})
+	ignoringEINTR2(func() (int, error) {
+		return unix.Write(w.closePipe[1], []byte{0})
+	})
 	unix.Close(w.closePipe[1])
 }
 
 func (w *Watcher) closeKq() error {
 	unix.Close(w.closePipe[0])
-	return unix.Close(w.kq)
+	return suppressEINTR(func() error {
+		return unix.Close(w.kq)
+	})
 }


### PR DESCRIPTION
Some syscalls may return an EINTR error.
When we get an EINTR error, we should retry the syscall.