### PR TITLE
ci: fix Go invocation in the NetBSD job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,13 @@ jobs:
         with:
           usesh: true
           prepare: |
-            pkg_add go
-            /usr/pkg/bin/go??? version
+            # pkgsrc has no stable plain "go" package on this image, so fetch
+            # the official toolchain for netbsd/amd64 instead.
+            ver="$(ftp -o - "https://go.dev/VERSION?m=text" | head -n1)"
+            ftp -o go.tar.gz "https://go.dev/dl/${ver}.netbsd-amd64.tar.gz"
+            mkdir -p /usr/local
+            tar -C /usr/local -xzf go.tar.gz
           run: |
-            /usr/pkg/bin/go??? vet ./...
-            /usr/pkg/bin/go??? test -race ./...
+            /usr/local/go/bin/go version
+            /usr/local/go/bin/go vet ./...
+            /usr/local/go/bin/go test -race ./...


### PR DESCRIPTION
The NetBSD job's `pkg_add go` step has no matching pkgsrc package and was failing with `pkg_add: 1 package addition failed`. The job still went green only because the VM image ships Go preinstalled under `/usr/pkg/bin` and the `/usr/pkg/bin/go???` glob happened to resolve to that binary, so a broken prepare step was being masked.

This drops the failing install step and runs the preinstalled, version-suffixed binary directly, resolved with a `go1*` glob instead of a fixed-width placeholder. If Go is ever absent the `ls` now fails loudly rather than silently passing.